### PR TITLE
Adding in query param hook

### DIFF
--- a/.env-development
+++ b/.env-development
@@ -6,6 +6,6 @@ API_NAMESPACE=v2
 API_DATA_NAMESPACE=Database
 API_ADMIN_NAMESPACE=Admin
 API_ERRORS_ENDPOINT=/error-events
-FASTBOOT_WHITELIST_DOMAIN=^gavant\.psybrarian\.com:\d+$
+FASTBOOT_WHITELIST_DOMAIN=^gavant\.pep-web\.rocks:\d+$
 ROBOTS_DIST_PATH=/robots-development.txt
 CLIENT_ID=2

--- a/pep/app/constants/search.ts
+++ b/pep/app/constants/search.ts
@@ -23,10 +23,7 @@ export interface SearchFacetType {
     paramSeparator: string;
     label: string;
     dynamicValues: boolean;
-    values: Array<{
-        id: string;
-        label: string;
-    }>;
+    values: { id: string; label: string }[];
 }
 
 export type SearchTermParam =

--- a/pep/app/hooks/useQueryParams.ts
+++ b/pep/app/hooks/useQueryParams.ts
@@ -1,0 +1,93 @@
+import { getOwner, setOwner } from '@ember/application';
+import { tracked } from '@glimmer/tracking';
+import DS from 'ember-data';
+import Controller from '@ember/controller';
+
+import { QueryParamsObj } from '@gavant/ember-pagination/utils/query-params';
+import Ember from 'ember';
+
+export type RecordArrayWithMeta<T> = DS.AdapterPopulatedRecordArray<T> & { meta: any };
+
+export interface ResponseMetadata {
+    totalCount: number;
+}
+
+export interface Sorting {
+    valuePath: string;
+    sortPath?: string;
+    isAscending: boolean;
+}
+
+export interface PaginationConfigs {
+    limit?: number;
+    filterList?: string[];
+    includeList?: string[];
+    pagingRootKey?: string | null;
+    filterRootKey?: string | null;
+    includeKey?: string;
+    sortKey?: string;
+    serverDateFormat?: string;
+    processQueryParams?: (params: QueryParamsObj) => QueryParamsObj;
+    onChangeSorting?: (sorts: string[], newSorts?: Sorting[]) => Promise<string[] | undefined> | void;
+}
+
+export interface QueryParamArgs {
+    context: Controller;
+    params: string[];
+}
+
+interface ControllerWithKeys extends Controller {
+    [key: string]: any;
+}
+
+export class QueryParams {
+    [key: string]: any;
+    /**
+     * The parent context object, usually a Controller or Component
+     * @type {*}
+     * @memberof Pagination
+     */
+    context: ControllerWithKeys;
+
+    queryParams: string[] | undefined = [];
+
+    constructor(args: QueryParamArgs) {
+        this.context = args.context;
+        this.queryParams = args.params;
+        this.queryParams.forEach((param) => {
+            // This handles tracking of object properties
+            //https://github.com/emberjs/ember.js/issues/18362
+            //@ts-ignore
+            Ember.defineProperty(this, param, tracked());
+            this[param] = this.context[param];
+        });
+    }
+
+    update() {
+        this.queryParams?.forEach((param) => {
+            this.context[param] = Ember.get(this, param);
+        });
+        // This tells the route that the params have been updated. We wouldn't need this if we
+        // didn't want to use object search params
+        if (Array.isArray(this.context.queryParams)) {
+            this.context.queryParams.forEach((param: any) => {
+                let delegate = this.context._qpDelegate;
+                delegate(param, Ember.get(this.context, param));
+            });
+        }
+    }
+}
+
+/**
+ * Creates and returns a new Pagination instance and binds its owner to be the same as
+ * that of its parent "context" (e.g. Controller, Component, etc).
+ * In most cases, this returned instance should be assigned to a @tracked property
+ * on its parent context, so that it can be accessed on the associated template
+ * @param {PaginationArgs} args
+ */
+export const useQueryParams = (args: QueryParamArgs) => {
+    const owner = getOwner(args.context);
+    const queryParams = new QueryParams(args);
+    setOwner(queryParams, owner);
+    return queryParams;
+};

--- a/pep/app/hooks/useQueryParams.ts
+++ b/pep/app/hooks/useQueryParams.ts
@@ -50,7 +50,7 @@ export class QueryParams {
  *
  * If using an object as a query param (eg. Model, POJO), be sure to add a computed to the getter
  * that grabs the value you need from the object
- * @param {PaginationArgs} args
+ * @param {QueryParamArgs} args
  */
 export const useQueryParams = (args: QueryParamArgs) => {
     const owner = getOwner(args.context);

--- a/pep/app/pods/components/modal-dialogs/user/about/component.ts
+++ b/pep/app/pods/components/modal-dialogs/user/about/component.ts
@@ -1,9 +1,5 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
-
-import ThemeService from 'pep/services/theme';
-import { ServerStatus } from 'pep/pods/components/page/nav/component';
+import { ServerStatus } from 'pep/pods/application/controller';
 
 interface ModalDialogsUserAboutArgs {
     onClose: () => void;

--- a/pep/app/pods/components/page/drawer/component.ts
+++ b/pep/app/pods/components/page/drawer/component.ts
@@ -7,7 +7,6 @@ import ModalService from '@gavant/ember-modals/services/modal';
 
 import DrawerService from 'pep/services/drawer';
 import AuthService from 'pep/services/auth';
-import AjaxService from 'pep/services/ajax';
 interface PageDrawerArgs {
     openAboutModal: () => Promise<void>;
 }

--- a/pep/app/pods/components/page/nav/component.ts
+++ b/pep/app/pods/components/page/nav/component.ts
@@ -7,9 +7,6 @@ import ModalService from '@gavant/ember-modals/services/modal';
 import AuthService from 'pep/services/auth';
 import DrawerService from 'pep/services/drawer';
 import { SEARCH_DEFAULT_TERMS, SEARCH_DEFAULT_FACETS } from 'pep/constants/search';
-import AjaxService from 'pep/services/ajax';
-import NotificationService from 'ember-cli-notifications/services/notifications';
-import LoadingBarService from 'pep/services/loading-bar';
 interface PageNavArgs {
     openAboutModal: () => Promise<void>;
 }

--- a/pep/app/pods/components/page/sidebar/widgets/most-cited/template.hbs
+++ b/pep/app/pods/components/page/sidebar/widgets/most-cited/template.hbs
@@ -7,7 +7,7 @@
     ...attributes
 as |Panel|>
     <Panel.header
-        @title={{t "relatedInfo.widgets.mostViewed.title"}}
+        @title={{t "relatedInfo.widgets.mostCited.title"}}
         @secondaryAction={{hash
             action=this.viewTable
             label=(t "common.viewAll")

--- a/pep/app/pods/most-cited/controller.ts
+++ b/pep/app/pods/most-cited/controller.ts
@@ -80,9 +80,9 @@ export default class MostCited extends Controller {
      */
     @action
     resetForm() {
-        this.author = '';
-        this.title = '';
-        this.journal = undefined;
+        this.searchQueryParams.author = '';
+        this.searchQueryParams.title = '';
+        this.searchQueryParams.journal = undefined;
     }
 
     /**

--- a/pep/app/pods/most-cited/controller.ts
+++ b/pep/app/pods/most-cited/controller.ts
@@ -10,6 +10,7 @@ import SidebarService from 'pep/services/sidebar';
 import IntlService from 'ember-intl/services/intl';
 import Journal from 'pep/pods/journal/model';
 import { PERIODS, PossiblePeriodValues } from 'pep/constants/sidebar';
+import { QueryParams } from 'pep/hooks/useQueryParams';
 
 export default class MostCited extends Controller {
     @service loadingBar!: LoadingBarService;
@@ -17,8 +18,8 @@ export default class MostCited extends Controller {
     @service sidebar!: SidebarService;
     @service intl!: IntlService;
 
-    queryParams = ['author', 'title', 'sourcename', 'period'];
-
+    queryParams = ['author', 'title', 'period', 'sourcename'];
+    @tracked searchQueryParams!: QueryParams;
     @tracked paginator!: Pagination<Document>;
     @tracked author = '';
     @tracked title = '';
@@ -59,6 +60,7 @@ export default class MostCited extends Controller {
     @action
     async filterTableResults() {
         try {
+            this.searchQueryParams.update();
             //close overlay sidebar on submit in mobile/tablet
             if (this.fastbootMedia.isSmallDevice) {
                 this.sidebar.toggleLeftSidebar();
@@ -90,7 +92,7 @@ export default class MostCited extends Controller {
      */
     @action
     updatePeriod(period: PossiblePeriodValues) {
-        this.period = period;
+        this.searchQueryParams.period = period;
     }
 
     /**
@@ -101,7 +103,7 @@ export default class MostCited extends Controller {
      */
     @action
     updateJournal(journal: Journal) {
-        this.journal = journal;
+        this.searchQueryParams.journal = journal;
     }
 }
 

--- a/pep/app/pods/most-cited/controller.ts
+++ b/pep/app/pods/most-cited/controller.ts
@@ -2,7 +2,7 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { Pagination } from '@gavant/ember-pagination/hooks/pagination';
 import Document from 'pep/pods/document/model';
-import { action } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import LoadingBarService from 'pep/services/loading-bar';
 import FastbootMediaService from 'pep/services/fastboot-media';
@@ -33,6 +33,7 @@ export default class MostCited extends Controller {
      *
      * @memberof MostCited
      */
+    @computed('journal.title')
     get sourcename() {
         return this.journal?.title ?? '';
     }

--- a/pep/app/pods/most-cited/nav/template.hbs
+++ b/pep/app/pods/most-cited/nav/template.hbs
@@ -11,7 +11,7 @@
                     <div class="form-group">
                         <FlSelect
                             @options={{this.periods}}
-                            @value={{this.period}}
+                            @value={{this.searchQueryParams.period}}
                             @valuePath="value"
                             @labelPath="label"
                             @placeholder={{t "mostCited.period"}}
@@ -23,7 +23,7 @@
                     <div class="form-group">
                         <FlInput
                             @placeholder={{t "mostCited.author"}}
-                            @value={{this.author}}
+                            @value={{this.searchQueryParams.author}}
                             maxlength="255"
                             autocomplete="off"
                         />
@@ -31,18 +31,18 @@
                     <div class="form-group">
                         <FlInput
                             @placeholder={{t "mostCited.title"}}
-                            @value={{this.title}}
+                            @value={{this.searchQueryParams.title}}
                             maxlength="255"
                             autocomplete="off"
                         />
                     </div>
                     <div class="form-group">
                         <FlInput
-                            @value={{this.journal}}
+                            @value={{this.searchQueryParams.journal}}
                             @placeholder={{t "mostCited.journal"}}
                         >
                             <PowerSelect::Journal
-                                @selected={{this.journal}}
+                                @selected={{this.searchQueryParams.journal}}
                                 @onChange={{this.updateJournal}}
                             />
                         </FlInput>

--- a/pep/app/pods/most-cited/route.ts
+++ b/pep/app/pods/most-cited/route.ts
@@ -3,7 +3,7 @@ import usePagination, { RecordArrayWithMeta } from '@gavant/ember-pagination/hoo
 import Document from 'pep/pods/document/model';
 import MostCitedController from 'pep/pods/most-cited/controller';
 import { PageNav } from 'pep/mixins/page-layout';
-import { buildQueryParams } from '@gavant/ember-pagination/utils/query-params';
+import { buildQueryParams, removeEmptyQueryParams } from '@gavant/ember-pagination/utils/query-params';
 import { useQueryParams } from 'pep/hooks/useQueryParams';
 import { SearchParams } from 'pep/pods/search/route';
 
@@ -24,7 +24,7 @@ export default class MostCited extends PageNav(Route) {
             filterList: ['author', 'title', 'sourcename', 'period', 'queryType'],
             processQueryParams: (params) => ({ ...params, ...queryParams })
         });
-        return this.store.query('document', apiQueryParams);
+        return this.store.query('document', removeEmptyQueryParams(apiQueryParams));
     }
 
     /**

--- a/pep/app/pods/most-cited/route.ts
+++ b/pep/app/pods/most-cited/route.ts
@@ -4,6 +4,9 @@ import Document from 'pep/pods/document/model';
 import MostCitedController from 'pep/pods/most-cited/controller';
 import { PageNav } from 'pep/mixins/page-layout';
 import { buildQueryParams } from '@gavant/ember-pagination/utils/query-params';
+import { useQueryParams } from 'pep/hooks/useQueryParams';
+import { SearchParams } from 'pep/pods/search/route';
+
 export default class MostCited extends PageNav(Route) {
     navController = 'most-cited';
 
@@ -13,14 +16,15 @@ export default class MostCited extends PageNav(Route) {
      * @returns {Promise<Document[]>}
      * @memberof MostCited
      */
-    async model() {
-        const queryParams = buildQueryParams({
+    async model(queryParams: SearchParams) {
+        const apiQueryParams = buildQueryParams({
             context: this.controllerFor('most-cited'),
             pagingRootKey: null,
             filterRootKey: null,
-            filterList: ['author', 'title', 'sourcename', 'period', 'queryType']
+            filterList: ['author', 'title', 'sourcename', 'period', 'queryType'],
+            processQueryParams: (params) => ({ ...params, ...queryParams })
         });
-        return this.store.query('document', queryParams);
+        return this.store.query('document', apiQueryParams);
     }
 
     /**
@@ -38,6 +42,10 @@ export default class MostCited extends PageNav(Route) {
             filterList: ['author', 'title', 'sourcename', 'period', 'queryType'],
             pagingRootKey: null,
             filterRootKey: null
+        });
+        controller.searchQueryParams = useQueryParams({
+            context: controller,
+            params: ['author', 'title', 'journal', 'period']
         });
     }
 }

--- a/pep/app/pods/most-cited/route.ts
+++ b/pep/app/pods/most-cited/route.ts
@@ -5,7 +5,13 @@ import MostCitedController from 'pep/pods/most-cited/controller';
 import { PageNav } from 'pep/mixins/page-layout';
 import { buildQueryParams, removeEmptyQueryParams } from '@gavant/ember-pagination/utils/query-params';
 import { useQueryParams } from 'pep/hooks/useQueryParams';
-import { SearchParams } from 'pep/pods/search/route';
+
+interface RouteQueryParams {
+    author: string;
+    title: string;
+    sourcename: string;
+    period: string;
+}
 
 export default class MostCited extends PageNav(Route) {
     navController = 'most-cited';
@@ -16,7 +22,7 @@ export default class MostCited extends PageNav(Route) {
      * @returns {Promise<Document[]>}
      * @memberof MostCited
      */
-    async model(queryParams: SearchParams) {
+    async model(queryParams: RouteQueryParams) {
         const apiQueryParams = buildQueryParams({
             context: this.controllerFor('most-cited'),
             pagingRootKey: null,

--- a/pep/app/pods/most-viewed/controller.ts
+++ b/pep/app/pods/most-viewed/controller.ts
@@ -2,7 +2,7 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { Pagination } from '@gavant/ember-pagination/hooks/pagination';
 import Document from 'pep/pods/document/model';
-import { action } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import LoadingBarService from 'pep/services/loading-bar';
 import FastbootMediaService from 'pep/services/fastboot-media';
@@ -10,6 +10,7 @@ import SidebarService from 'pep/services/sidebar';
 import IntlService from 'ember-intl/services/intl';
 import Journal from 'pep/pods/journal/model';
 import { PERIODS, PossiblePeriodValues } from 'pep/constants/sidebar';
+import { QueryParams } from 'pep/hooks/useQueryParams';
 
 export default class MostViewed extends Controller {
     @service loadingBar!: LoadingBarService;
@@ -18,7 +19,7 @@ export default class MostViewed extends Controller {
     @service intl!: IntlService;
 
     queryParams = ['author', 'title', 'sourcename', 'period'];
-
+    @tracked searchQueryParams!: QueryParams;
     @tracked paginator!: Pagination<Document>;
     @tracked author = '';
     @tracked title = '';
@@ -33,6 +34,7 @@ export default class MostViewed extends Controller {
      *
      * @memberof MostViewed
      */
+    @computed('journal.title')
     get sourcename() {
         return this.journal?.title ?? '';
     }
@@ -57,6 +59,7 @@ export default class MostViewed extends Controller {
     @action
     async filterTableResults() {
         try {
+            this.searchQueryParams.update();
             //close overlay sidebar on submit in mobile/tablet
             if (this.fastbootMedia.isSmallDevice) {
                 this.sidebar.toggleLeftSidebar();
@@ -90,12 +93,12 @@ export default class MostViewed extends Controller {
      */
     @action
     updatePeriod(period: PossiblePeriodValues) {
-        this.period = period;
+        this.searchQueryParams.period = period;
     }
 
     @action
     updateJournal(journal: Journal) {
-        this.journal = journal;
+        this.searchQueryParams.journal = journal;
     }
 }
 // DO NOT DELETE: this is how TypeScript knows how to look up your controllers.

--- a/pep/app/pods/most-viewed/controller.ts
+++ b/pep/app/pods/most-viewed/controller.ts
@@ -80,9 +80,9 @@ export default class MostViewed extends Controller {
      */
     @action
     resetForm() {
-        this.author = '';
-        this.title = '';
-        this.journal = undefined;
+        this.searchQueryParams.author = '';
+        this.searchQueryParams.title = '';
+        this.searchQueryParams.journal = undefined;
     }
 
     /**

--- a/pep/app/pods/most-viewed/nav/template.hbs
+++ b/pep/app/pods/most-viewed/nav/template.hbs
@@ -11,7 +11,7 @@
                     <div class="form-group">
                         <FlSelect
                             @options={{this.periods}}
-                            @value={{this.period}}
+                            @value={{this.searchQueryParams.period}}
                             @valuePath="value"
                             @labelPath="label"
                             @placeholder={{t "mostCited.period"}}
@@ -23,7 +23,7 @@
                     <div class="form-group">
                         <FlInput
                             @placeholder={{t "mostCited.author"}}
-                            @value={{this.author}}
+                            @value={{this.searchQueryParams.author}}
                             maxlength="255"
                             autocomplete="off"
                         />
@@ -31,18 +31,18 @@
                     <div class="form-group">
                         <FlInput
                             @placeholder={{t "mostCited.title"}}
-                            @value={{this.title}}
+                            @value={{this.searchQueryParams.title}}
                             maxlength="255"
                             autocomplete="off"
                         />
                     </div>
                     <div class="form-group">
                         <FlInput
-                            @value={{this.journal}}
+                            @value={{this.searchQueryParams.journal}}
                             @placeholder={{t "mostCited.journal"}}
                         >
                             <PowerSelect::Journal
-                                @selected={{this.journal}}
+                                @selected={{this.searchQueryParams.journal}}
                                 @onChange={{this.updateJournal}}
                             />
                         </FlInput>

--- a/pep/app/pods/most-viewed/route.ts
+++ b/pep/app/pods/most-viewed/route.ts
@@ -3,7 +3,7 @@ import usePagination, { RecordArrayWithMeta } from '@gavant/ember-pagination/hoo
 import Document from 'pep/pods/document/model';
 import MostViewedController from 'pep/pods/most-viewed/controller';
 import { PageNav } from 'pep/mixins/page-layout';
-import { buildQueryParams } from '@gavant/ember-pagination/utils/query-params';
+import { buildQueryParams, removeEmptyQueryParams } from '@gavant/ember-pagination/utils/query-params';
 import { useQueryParams } from 'pep/hooks/useQueryParams';
 
 export default class MostViewed extends PageNav(Route) {
@@ -19,7 +19,7 @@ export default class MostViewed extends PageNav(Route) {
             filterList: ['author', 'title', 'sourcename', 'period', 'queryType'],
             processQueryParams: (params) => ({ ...params, ...queryParams })
         });
-        return this.store.query('document', apiQueryParams);
+        return this.store.query('document', removeEmptyQueryParams(apiQueryParams));
     }
 
     /**

--- a/pep/app/pods/most-viewed/route.ts
+++ b/pep/app/pods/most-viewed/route.ts
@@ -6,12 +6,19 @@ import { PageNav } from 'pep/mixins/page-layout';
 import { buildQueryParams, removeEmptyQueryParams } from '@gavant/ember-pagination/utils/query-params';
 import { useQueryParams } from 'pep/hooks/useQueryParams';
 
+interface RouteQueryParams {
+    author: string;
+    title: string;
+    sourcename: string;
+    period: string;
+}
+
 export default class MostViewed extends PageNav(Route) {
     navController = 'most-viewed';
     /**
      * Load the widget results data
      */
-    async model(queryParams: any[]) {
+    async model(queryParams: RouteQueryParams) {
         const apiQueryParams = buildQueryParams({
             context: this.controllerFor('most-viewed'),
             pagingRootKey: null,

--- a/pep/app/pods/most-viewed/route.ts
+++ b/pep/app/pods/most-viewed/route.ts
@@ -4,20 +4,22 @@ import Document from 'pep/pods/document/model';
 import MostViewedController from 'pep/pods/most-viewed/controller';
 import { PageNav } from 'pep/mixins/page-layout';
 import { buildQueryParams } from '@gavant/ember-pagination/utils/query-params';
+import { useQueryParams } from 'pep/hooks/useQueryParams';
 
 export default class MostViewed extends PageNav(Route) {
     navController = 'most-viewed';
     /**
      * Load the widget results data
      */
-    async model() {
-        const queryParams = buildQueryParams({
+    async model(queryParams: any[]) {
+        const apiQueryParams = buildQueryParams({
             context: this.controllerFor('most-viewed'),
             pagingRootKey: null,
             filterRootKey: null,
-            filterList: ['author', 'title', 'sourcename', 'period', 'queryType']
+            filterList: ['author', 'title', 'sourcename', 'period', 'queryType'],
+            processQueryParams: (params) => ({ ...params, ...queryParams })
         });
-        return this.store.query('document', queryParams);
+        return this.store.query('document', apiQueryParams);
     }
 
     /**
@@ -35,6 +37,10 @@ export default class MostViewed extends PageNav(Route) {
             filterList: ['author', 'title', 'sourcename', 'period', 'queryType'],
             pagingRootKey: null,
             filterRootKey: null
+        });
+        controller.searchQueryParams = useQueryParams({
+            context: controller,
+            params: ['author', 'title', 'journal', 'period']
         });
     }
 }


### PR DESCRIPTION
Adding in the query param "hook". This allows us to manually control the query params and when they update i.e. on button click. 

The downside here is that we are using a private property on the controller to update the query params. This property seems to tell both the route and controller that things were updated. Otherwise, seems like a decent strategy. 