### PR TITLE
dark mode tweaks

### DIFF
--- a/pep/app/styles/themes/dark.scss
+++ b/pep/app/styles/themes/dark.scss
@@ -14,7 +14,7 @@
 // Application variables
 // ---------------------------
 $logo-path: '/assets/images/logo-dark.jpg';
-$color-brand-primary: #56698f;
+$color-brand-primary: #5c74a2;
 $color-input-bg: #2f3136;
 $color-backdrop: #36393f;
 $color-primary-background: #393c43;
@@ -52,7 +52,7 @@ $body-bg: darken($color-backdrop, 2%);
 $body-color: #dbdddc;
 $dark: $body-color;
 $input-color: $body-color;
-$link-color: saturate(lighten($color-brand-primary, 25%), 5%);
+$link-color: saturate(lighten($color-brand-primary, 24%), 22%);
 $input-border-color: $color-input-bg;
 $input-bg: $color-input-bg;
 $input-focus-border-color: lighten($color-input-bg, 20%);

--- a/pep/tests/integration/pods/components/home/component-test.ts
+++ b/pep/tests/integration/pods/components/home/component-test.ts
@@ -8,8 +8,9 @@ import { module, test } from 'qunit';
 module('Integration | Component | home', function(hooks) {
     setupRenderingTest(hooks);
 
-    hooks.beforeEach(function(assert) {
+    hooks.beforeEach(function() {
         // fixes issue with the component accessing router.urlFor() in its did-insert
+        //@ts-ignore implicit any for `this` is needed here
         this.owner.lookup('router:main').setupRouter();
     });
 


### PR DESCRIPTION
Bumps up the saturation of the dark theme's primary call-to-action/link color, to improve the contrast/vibrance and reduce the "washed out" feel. Maintains the softer purple-ish blue though, to avoid the somewhat eye-hurting effect of the original electric blue color (esp. when many links are on screen at once), and to better carry through PEP's original purple-y branding color scheme.

The new colors pass WCAG A and AA for all font sizes (the client spec only requires passing A level, so this should be fine for the dark theme, but maybe we can aim for AAA compliance in the default and/or high contrast themes).