### PR TITLE
feature/support-multiple-ijpo-versions

### DIFF
--- a/pep/app/pods/components/disqus/comments/component.ts
+++ b/pep/app/pods/components/disqus/comments/component.ts
@@ -51,7 +51,11 @@ export default class DisqusComments extends Component<DisqusCommentsSignature> {
      */
     private resetDisqus() {
         const id = this.args.identifier.toLowerCase() ?? undefined;
-        const identifier = !this.args.url && id;
+
+        // Always use the first version of an article to persist comments across versions
+        // We could slice off the version entirely, but we need to maintain backawrds compatibiltiy for existing Disqus thread IDs
+        const identifier = !this.args.url && id.slice(0, -1) + 'a';
+
         const url = this.args.url || window.location.href;
         const title = this.args.title ?? undefined;
 

--- a/pep/public/xmlToHtml.xslt
+++ b/pep/public/xmlToHtml.xslt
@@ -203,6 +203,9 @@
     <xsl:variable name="artstartpg">
         <xsl:value-of select="substring-before(($artpgrg), '-')"/>
     </xsl:variable>
+        <xsl:variable name="latest-version-id">
+        <xsl:apply-templates select="//artinfo/@latest_version_id"/>
+    </xsl:variable>
 
     <xsl:template match="pepkbd3">
         <body>
@@ -269,6 +272,17 @@
                         <div class="section-title section-title border-bottom my-2">
                             <xsl:apply-templates mode="metadata" select="artsectinfo" />
                         </div>
+                    </xsl:if>
+                     <xsl:if test="$latest-version-id != ''">
+                        <p class="para mt-3 text-center">
+                            <a href="/browse/document/{$latest-version-id}"
+                               data-type="document-link"
+                               data-document-id="{$latest-version-id}"
+                            >
+                                &#128680;You are reading an older version of this article. Click here to view the latest revision&#128680;
+                            </a>
+                        </p>
+                  
                     </xsl:if>
                     <div class="art-title mt-3 text-center">
                         <span>


### PR DESCRIPTION
Support proposed IJPO functionality within PEP-Web

- Use the original document thread ID across all versions of an article
- When viewing an old version of a document, display a link to the newest version
- Multiple document versions are displayed within the same ToC

<img width="610" alt="image" src="https://user-images.githubusercontent.com/79658146/205070183-81dcc402-b9a6-443c-acb3-c2c0abd54290.png">

