### PR TITLE
Bug/user-service-missing-from-nav-component

### DIFF
--- a/pep/app/pods/components/page/nav/component.ts
+++ b/pep/app/pods/components/page/nav/component.ts
@@ -17,6 +17,7 @@ import ConfigurationService from 'pep/services/configuration';
 import DrawerService from 'pep/services/drawer';
 import PepSessionService from 'pep/services/pep-session';
 import { BaseGlimmerSignature } from 'pep/utils/types';
+import CurrentUserService from 'pep/services/current-user';
 
 interface PageNavArgs {
     openAboutModal: () => Promise<void>;
@@ -31,6 +32,7 @@ export default class PageNav extends Component<BaseGlimmerSignature<PageNavArgs>
     @service configuration!: ConfigurationService;
     @service router!: RouterService;
     @service notifications!: NotificationService;
+    @service currentUser!: CurrentUserService;
 
     @tracked shortcuts: KeyboardShortcut[] = [
         {

--- a/pep/app/services/current-user.ts
+++ b/pep/app/services/current-user.ts
@@ -179,8 +179,6 @@ export default class CurrentUserService extends Service {
         const id = sessionId ?? this.session.sessionId;
         const user = await this.store.queryRecord('user', { SessionId: id ?? '' });
 
-        console.log('USER:', user);
-
         this.user = user;
         return user;
     }


### PR DESCRIPTION
A previous PR prematurely removed the user service from the navigation component

Without this service, the navigation bar was unable to determine a user's admin status resulting in admin users being unable to access to the admin settings
