### PR TITLE
story/ijp-open-banner

### DIFF
--- a/pep/app/pods/components/alert/component.ts
+++ b/pep/app/pods/components/alert/component.ts
@@ -14,6 +14,8 @@ interface AlertArgs {
     icon?: IconName;
     scrollableNamespace?: string;
     animateInitialInsert?: boolean;
+    dissmisable?: boolean;
+    onDismiss?: () => void;
 }
 
 export default class Alert extends Component<BaseGlimmerSignature<AlertArgs>> {

--- a/pep/app/pods/components/alert/template.hbs
+++ b/pep/app/pods/components/alert/template.hbs
@@ -5,7 +5,12 @@
         duration=this.animateDuration
         initialInsertion=this.animateInitialInsert
     }}
-        <div class="alert alert-{{@type}}" role="alert" ...attributes>
+        <div class="alert alert-{{@type}} alert-dismissable" role="alert" ...attributes>
+            {{#if @dissmissable}}
+                <button onclick={{@onDismiss}} type="button" class="close" data-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            {{/if}}
             {{#if (has-block)}}
                 {{yield}}
             {{else}}

--- a/pep/app/pods/components/document/read/component.ts
+++ b/pep/app/pods/components/document/read/component.ts
@@ -19,6 +19,8 @@ import LoadingBarService from 'pep/services/loading-bar';
 import PepSessionService from 'pep/services/pep-session';
 import { clearSearch } from 'pep/utils/search';
 import { BaseGlimmerSignature } from 'pep/utils/types';
+import { tracked } from '@glimmer/tracking';
+import CookiesService from 'ember-cookies/services/cookies';
 
 interface DocumentReadArgs {
     model: Document;
@@ -38,9 +40,19 @@ export default class DocumentRead extends Component<BaseGlimmerSignature<Documen
     @service loadingBar!: LoadingBarService;
     @service store!: DS.Store;
     @service('pep-session') session!: PepSessionService;
+    @service cookies!: CookiesService;
 
     get hasWatermark() {
         return this.args.model.PEPCode === IJP_OPEN_CODE;
+    }
+
+    @tracked showIJPOpenBannerState = true;
+    get showIJPOpenBanner() {
+        if (this.args.model.PEPCode !== IJP_OPEN_CODE) return false;
+
+        if (this.cookies.read('IJPOpenBannerClosed') === '1') return false;
+
+        return this.showIJPOpenBannerState;
     }
 
     /**
@@ -88,6 +100,12 @@ export default class DocumentRead extends Component<BaseGlimmerSignature<Documen
     @action
     documentRendered() {
         this.args.documentRendered?.();
+    }
+
+    @action
+    dismissIJPOpenBanner() {
+        this.cookies.write('IJPOpenBannerClosed', '1', {});
+        this.showIJPOpenBannerState = false;
     }
 }
 

--- a/pep/app/pods/components/document/read/template.hbs
+++ b/pep/app/pods/components/document/read/template.hbs
@@ -19,6 +19,22 @@
             </Alert>
             <div class="pep-document-content" id="read-document">
                 <ContentWithPlaceholder @placeholderInFastboot={{true}} @isLoading={{not @model}}>
+
+                    {{! IJP Open Banner }}
+                    <Alert
+                        @isShown={{this.showIJPOpenBanner}}
+                        @type="info"
+                        @dissmissable={{true}}
+                        @onDismiss={{this.dismissIJPOpenBanner}}
+                    >
+                        To comment on IJP Open, you have automatically been asigned a Disqus identity. You can view and
+                        contribute to article discussions by clicking on the comment icon (
+                        <FaIcon @icon="comments" @size="sm" />
+                        ) in the top right.
+
+                    </Alert>
+
+                    {{! Document contents }}
                     <Document::Text
                         @document={{@model}}
                         @onGlossaryItemClick={{this.viewGlossaryTerm}}

--- a/pep/app/pods/components/document/read/template.hbs
+++ b/pep/app/pods/components/document/read/template.hbs
@@ -27,10 +27,10 @@
                         @dissmissable={{true}}
                         @onDismiss={{this.dismissIJPOpenBanner}}
                     >
-                        To comment on IJP Open, you have automatically been asigned a Disqus identity. You can view and
+                        To comment on IJP Open, you have automatically been asigned a Disqus profile. You can view and
                         contribute to article discussions by clicking on the comment icon (
                         <FaIcon @icon="comments" @size="sm" />
-                        ) in the top right.
+                        ) in the top right corner.
 
                     </Alert>
 


### PR DESCRIPTION
Add an info banner to the top of IJP Open articles explaining how to comment

Add dismissal functionality to existing alert component

When an IJP Open banner is dismissed, store the dismissal state in cookies

Only display the IJP Open banner if the user has not yet dismissed it during their browser session